### PR TITLE
Add PKI game demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Dieses Projekt demonstriert eine einfache Flask-Webanwendung, die Server einer W
 python -m server_status.app
 ```
 Die Webseite ist anschließend unter [http://localhost:5000](http://localhost:5000) erreichbar.
+
+### PKI Jump-and-Run
+Im Browser steht unter `/pki-game` ein kleines Jump-and-Run-Spiel bereit. Es vermittelt spielerisch die Konzepte von Public-Key-Infrastrukturen wie Public Key, Private Key und Zertifikate.
+

--- a/server_status/app.py
+++ b/server_status/app.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, render_template
+from flask import Flask, render_template, url_for
 from .status import collect_status
 
 # Locate the template folder one directory above this package so
@@ -14,5 +14,11 @@ def index():
     servers = collect_status()
     return render_template('index.html', servers=servers)
 
+
+@app.route('/pki-game')
+def pki_game():
+    return render_template('pki_game.html')
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)
+

--- a/static/js/pki_game.js
+++ b/static/js/pki_game.js
@@ -1,0 +1,75 @@
+var info;
+var cursors;
+var player;
+var tokens;
+
+function preload() {
+    // no assets to preload
+}
+
+function create() {
+    info = document.getElementById('info');
+
+    const ground = this.add.rectangle(400, 390, 800, 20, 0x654321);
+    this.physics.add.existing(ground, true);
+
+    player = this.add.rectangle(100, 340, 32, 48, 0x0000ff);
+    this.physics.add.existing(player);
+    player.body.setCollideWorldBounds(true);
+
+    cursors = this.input.keyboard.createCursorKeys();
+    this.physics.add.collider(player, ground);
+
+    tokens = this.physics.add.group();
+    addToken.call(this, 200, 350, 'Public Key: Ein \u00f6ffentlicher Schl\u00fcssel wird zum Verschl\u00fcsseln verwendet.');
+    addToken.call(this, 400, 350, 'Private Key: Ein privater Schl\u00fcssel dient zum Entschl\u00fcsseln und muss geheim bleiben.');
+    addToken.call(this, 600, 350, 'Zertifikat: Beglaubigt den \u00f6ffentlichen Schl\u00fcssel eines Kommunikationspartners.');
+
+    this.physics.add.collider(tokens, ground);
+    this.physics.add.overlap(player, tokens, collectToken, null, this);
+}
+
+function addToken(x, y, message) {
+    const token = this.add.rectangle(x, y - 20, 20, 20, 0xff0000);
+    this.physics.add.existing(token);
+    token.body.setBounce(0.2);
+    token.message = message;
+    tokens.add(token);
+}
+
+function collectToken(player, token) {
+    token.disableBody(true, true);
+    info.innerText = token.message;
+    info.style.display = 'block';
+}
+
+function update() {
+    if (cursors.left.isDown) {
+        player.body.setVelocityX(-160);
+    } else if (cursors.right.isDown) {
+        player.body.setVelocityX(160);
+    } else {
+        player.body.setVelocityX(0);
+    }
+
+    if (cursors.up.isDown && player.body.blocked.down) {
+        player.body.setVelocityY(-330);
+    }
+}
+
+var config = {
+    type: Phaser.AUTO,
+    width: 800,
+    height: 400,
+    parent: 'game',
+    physics: {
+        default: 'arcade',
+        arcade: {
+            gravity: { y: 500 },
+            debug: false
+        }
+    },
+    scene: { preload: preload, create: create, update: update }
+};
+
+new Phaser.Game(config);

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
 <body>
 <div class="container mt-4">
     <h1>Server Status</h1>
+    <a class="btn btn-primary mb-3" href="/pki-game">Zum PKI-Spiel</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/templates/pki_game.html
+++ b/templates/pki_game.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>PKI Jump and Run</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.js"></script>
+</head>
+<body>
+<div class="container mt-4">
+    <h1>PKI Jump and Run</h1>
+    <p>Steuere die Figur mit den Pfeiltasten. Sammle alle Symbole ein, um mehr über PKI zu erfahren.</p>
+    <div id="game"></div>
+    <div id="info" class="mt-3 alert alert-info" style="display:none;"></div>
+    <a class="btn btn-secondary mt-3" href="/">Zurück zur Übersicht</a>
+</div>
+<script src="{{ url_for('static', filename='js/pki_game.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `/pki-game` route
- create a simple Phaser based jump and run teaching PKI concepts
- link game from the start page
- document PKI game in README

## Testing
- `python -m server_status.app` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686e50cffa3c832fbcd0a72aaad9c6c4